### PR TITLE
Use base instead of self for clarity

### DIFF
--- a/lib/arca/collector.rb
+++ b/lib/arca/collector.rb
@@ -86,7 +86,7 @@ module Arca
             end
 
             # Bind the callback method to self and call it with args.
-            callback_method.bind(self).call(*args)
+            callback_method.bind(base).call(*args)
           end
         end
       end


### PR DESCRIPTION
``` ruby
[1] pry(Ticket)> base == self
=> true
```

Decided to just use base here for clarity.
