### PR TITLE
Revert "Use base instead of self for clarity"

### DIFF
--- a/lib/arca/collector.rb
+++ b/lib/arca/collector.rb
@@ -80,7 +80,7 @@ module Arca
             end
 
             # Bind the callback method to self and call it with args.
-            callback_method.bind(base).call(*args)
+            callback_method.bind(self).call(*args)
           end
         end
       end


### PR DESCRIPTION
Reverts jonmagic/arca#2

Changing this to base was a mistake, it needs to be bound to the class where the method is run, not the class where the module is included.
