### PR TITLE
Adds support for the :on conditional

### DIFF
--- a/lib/arca/callback_analysis.rb
+++ b/lib/arca/callback_analysis.rb
@@ -113,7 +113,9 @@ module Arca
     # Public: Boolean representing whether the conditional target is located in
     # the same file where the callback is defined.
     def external_conditional_target?
-      return if conditional_target_symbol.nil?
+      return false if conditional_target_symbol.nil?
+      return false if conditional_target_symbol.is_a?(Array)
+      return false if [:create, :update, :destroy].include?(conditional_target_symbol)
 
       callback_file_path != conditional_target_file_path
     end

--- a/test/fixtures/ticket.rb
+++ b/test/fixtures/ticket.rb
@@ -3,6 +3,7 @@ class Ticket < ActiveRecord::Base
 
   before_save :set_title, :set_body
   before_save :upcase_title, :if => :title_is_a_shout?
+  after_commit :update_timeline, :on => [:create, :destroy]
 
   def set_title
     self.title ||= "Ticket id #{SecureRandom.hex(2)}"
@@ -18,5 +19,9 @@ class Ticket < ActiveRecord::Base
 
   def title_is_a_shout?
     self.title.split(" ").size == 1
+  end
+
+  def update_timeline
+    puts "Updating timeline"
   end
 end

--- a/test/lib/arca/callback_analysis_test.rb
+++ b/test/lib/arca/callback_analysis_test.rb
@@ -85,8 +85,8 @@ class Arca::CallbackAnalysisTest < Minitest::Test
 
   def test_target_line_number
     assert_equal 9, announce_save.target_line_number
-    assert_equal 7, set_title.target_line_number
-    assert_equal 15, upcase_title.target_line_number
+    assert_equal 8, set_title.target_line_number
+    assert_equal 16, upcase_title.target_line_number
   end
 
   def test_external_target?
@@ -97,8 +97,8 @@ class Arca::CallbackAnalysisTest < Minitest::Test
 
   def test_lines_to_target
     assert_equal 5, announce_save.lines_to_target
-    assert_equal 2, set_title.lines_to_target
-    assert_equal 9, upcase_title.lines_to_target
+    assert_equal 3, set_title.lines_to_target
+    assert_equal 10, upcase_title.lines_to_target
   end
 
   def test_conditional_symbol
@@ -122,12 +122,12 @@ class Arca::CallbackAnalysisTest < Minitest::Test
   def test_conditional_target_line_number
     assert_nil announce_save.conditional_target_line_number
     assert_nil set_title.conditional_target_line_number
-    assert_equal 19, upcase_title.conditional_target_line_number
+    assert_equal 20, upcase_title.conditional_target_line_number
   end
 
   def test_lines_to_conditional_target
     assert_nil announce_save.lines_to_conditional_target
     assert_nil set_title.lines_to_conditional_target
-    assert_equal 13, upcase_title.lines_to_conditional_target
+    assert_equal 14, upcase_title.lines_to_conditional_target
   end
 end

--- a/test/lib/arca/collector_test.rb
+++ b/test/lib/arca/collector_test.rb
@@ -5,6 +5,7 @@ class Arca::CollectorTest < Minitest::Test
     callbacks = Ticket.arca_callback_data
     assert_equal 1, callbacks[:after_save].size
     assert_equal 4, callbacks[:before_save].size
+    assert_equal 1, callbacks[:after_commit].size
 
     callback = callbacks[:after_save][0]
     assert_equal :after_save, callback[:callback_symbol]
@@ -45,6 +46,14 @@ class Arca::CollectorTest < Minitest::Test
     assert_equal :upcase_title, callback[:target_symbol]
     assert_equal :if, callback[:conditional_symbol]
     assert_equal :title_is_a_shout?, callback[:conditional_target_symbol]
+
+    callback = callbacks[:after_commit][0]
+    assert_equal :after_commit, callback[:callback_symbol]
+    assert_match "test/fixtures/ticket.rb", callback[:callback_file_path]
+    assert_equal 6, callback[:callback_line_number]
+    assert_equal :update_timeline, callback[:target_symbol]
+    assert_equal :on, callback[:conditional_symbol]
+    assert_equal [:create, :destroy], callback[:conditional_target_symbol]
   end
 
   def test_callback_is_reapplied_with_original_args

--- a/test/lib/arca/model_test.rb
+++ b/test/lib/arca/model_test.rb
@@ -12,7 +12,7 @@ class Arca::ModelTest < Minitest::Test
   def test_source_location
     source_location = model.source_location(:set_title)
     assert_match "test/fixtures/ticket.rb", source_location[:file_path]
-    assert_equal 7, source_location[:line_number]
+    assert_equal 8, source_location[:line_number]
   end
 
   def test_source_location_with_method_symbol_with_no_associated_method
@@ -33,16 +33,16 @@ class Arca::ModelTest < Minitest::Test
   end
 
   def test_analyzed_callbacks_array
-    assert_equal 5, model.analyzed_callbacks_array.size
+    assert_equal 6, model.analyzed_callbacks_array.size
     assert model.analyzed_callbacks_array[0].is_a?(Arca::CallbackAnalysis)
   end
 
   def test_analyzed_callbacks_count
-    assert_equal 5, model.analyzed_callbacks_count
+    assert_equal 6, model.analyzed_callbacks_count
   end
 
   def test_lines_between_count
-    assert_equal 5, model.lines_between_count
+    assert_equal 6, model.lines_between_count
   end
 
   def test_external_callbacks_count

--- a/test/lib/arca/report_test.rb
+++ b/test/lib/arca/report_test.rb
@@ -14,14 +14,14 @@ class Arca::ReportTest < Minitest::Test
   end
 
   def callbacks_count
-    assert_equal 4, report.callbacks_count
+    assert_equal 5, report.callbacks_count
   end
 
   def test_conditionals_count
-    assert_equal 1, report.conditionals_count
+    assert_equal 2, report.conditionals_count
   end
 
   def test_calculated_permutations
-    assert_equal 2, report.calculated_permutations
+    assert_equal 3, report.calculated_permutations
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ require "minitest/autorun"
 require "arca"
 
 class ActiveRecord::Base
+  self.raise_in_transactional_callbacks = true
   include Arca::Collector
 end
 


### PR DESCRIPTION
Support `:on` as a conditional.

``` ruby
before_commit :foo, :on => :create
```
