### PR TITLE
Add lint testing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Arca helps you answer questions like:
 
 The Arca library has two main components, the collector and the reporter. Include the collector module in ActiveRecord::Base before your models are loaded.
 
+At GitHub, we test callbacks by whitelist existing callbacks, and adding a lint
+test to ensure new callbacks are not added without review. The
+[examples](examples) folder is a good starting point.
+
 ## Requirements
 
 ![travis-ci build status](https://travis-ci.org/jonmagic/arca.svg)
@@ -34,8 +38,9 @@ class ActiveRecord::Base
   include Arca::Collector
 end
 
-# load your app. It's important to setup before loading your models because arca
-# works by record callback definitions.
+# load your app. It's important to setup before loading your models because Arca
+# works by wrapping itself around the callback method definitions (before_save,
+# after_save, etc) and then records how and where those methods are used.
 ```
 
 In this example the `Annoucements` module is included in `Ticket` and defines it's own callback.
@@ -212,10 +217,6 @@ Please /cc @github/migration on the PR if you
 have to update this test to make it pass.
 ---------------------------------------------
 ```
-
-Another approach to testing callbacks is to whitelist existing callbacks, and
-add a lint test to ensure new callbacks are not added without review. The
-[examples](examples) is a good starting point.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ have to update this test to make it pass.
 ---------------------------------------------
 ```
 
+Another approach to testing callbacks is to whitelist existing callbacks, and
+add a lint test to ensure new callbacks are not added without review. The
+[examples](examples) is a good starting point.
+
 ## License
 
 The MIT License (MIT)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ class ActiveRecord::Base
   include Arca::Collector
 end
 
-# load your app
+# load your app. It's important to setup before loading your models because arca
+# works by record callback definitions.
 ```
 
 In this example the `Annoucements` module is included in `Ticket` and defines it's own callback.

--- a/examples/active_record_lint_test.rb
+++ b/examples/active_record_lint_test.rb
@@ -1,0 +1,42 @@
+require "minitest"
+
+class ActiveRecordLintTest < Minitest::Test
+  def test_callbacks_must_be_defined_in_the_base_model_file
+    whitelist_path = File.expand_path("../active_record_callback_whitelist.txt", __FILE__)
+    whitelisted_callbacks = if File.exists?(whitelist_path)
+      File.read(whitelist_path).split("\n")
+    else
+      ""
+    end
+
+    # git grep... list classes with a parent. Does not handle classes nested within a module
+    # xargs... arca analyze. We skip line numbers so we can diff the results
+    # grep... filter for callbacks defined in external files or callbacks without names
+    #
+    # To update the whitelist, save the output up to script/audit-callbacks.
+    callback_output = IO.popen(<<-CMD).read
+      git grep -h '^class.*< ' -- '*.rb' | cut -d' ' -f 2 | sort -u | \
+      xargs bundle exec audit-callbaks.rb --skip-line-num | \
+      grep -E 'external:true|block$'
+    CMD
+
+    actual_callbacks = callback_output.split("\n")
+
+    new_bad_callbacks = actual_callbacks - whitelisted_callbacks
+    unnecessary_whitelist_entries = whitelisted_callbacks - actual_callbacks
+
+    message = ""
+    if new_bad_callbacks.any?
+      message << "The following ActiveRecord callbacks must be defined in the base model file with a named method:\n\n"
+      message << new_bad_callbacks.join("\n")
+    end
+
+    if unnecessary_whitelist_entries.any?
+      message << "\n\n" unless message.empty?
+      message << "Hooray! You removed a bad ActiveRecord callback. Please update #{whitelist_path} and remove the following\n\n"
+      message << unnecessary_whitelist_entries.join("\n")
+    end
+
+    assert message.empty?, message
+  end
+end

--- a/examples/audit-callbacks.rb
+++ b/examples/audit-callbacks.rb
@@ -1,0 +1,75 @@
+# Prints a list of Active Record callbacks for the given models
+#
+# Usage:
+#   bundle exec audit-callbacks.rb [--skip-line-num] [Model1 Model2...]
+#
+skip_line_num = false
+if ARGV.first == "--skip-line-num"
+  ARGV.shift
+  skip_line_num = true
+end
+
+unless ARGV.size > 0
+  $stderr.puts "No models specified. Try script/audit-callbacks User Issue."
+  exit 1
+end
+
+# Arca must be required after ActiveRecord, but before the environment loads so
+# we can install Arca::Collector.
+require "active_record"
+require "arca"
+class ActiveRecord::Base
+  include Arca::Collector
+end
+
+require "config/environment"
+
+# Returns a formatted string of a callback analysis.
+#
+# Examples:
+#
+# An unnamed (block) before_destroy callback defined in the same file as the model
+# Ability before_destroy app/models/ability.rb external:false block
+#
+# A after_destroy callback named `dereference_asset` defined in a file outside of the model (external:true)
+# Avatar after_destroy app/models/asset_uploadable.rb external:true dereference_asset
+#
+# A before_save callback defined by a callback class
+# IssueComment before_save app/models/referrer.rb external:true Referrer::ReferenceMentionsCallback
+#
+def format_callback(callback, skip_line_num:)
+  path = Arca.relative_path(callback.callback_file_path)
+  path << ":#{callback.callback_line_number}" unless skip_line_num
+
+  # Arca outputs object ids which triggers a diff
+  # e.g. #<Referrer::ReferenceMentionsCallback:0x007f8bca3a1b48>
+  target = if match = /#<(.+):.+>/.match(callback.target_symbol.to_s)
+    match[1]
+  else
+    callback.target_symbol
+  end
+
+  [
+    callback.model.name,
+    callback.callback_symbol,
+    path,
+    "external:#{callback.external_callback?}",
+    target
+  ].map(&:to_s).join(" ")
+end
+
+ARGV.each do |model_name|
+  begin
+    model_class = model_name.constantize
+  rescue NameError # test classes
+    next
+  end
+
+  next unless model_class.ancestors.include?(ActiveRecord::Base)
+
+  Arca[model_class].analyzed_callbacks.each do |callback_symbol, callbacks|
+    callbacks.each do |callback|
+      puts format_callback(callback, skip_line_num: skip_line_num)
+    end
+  end
+end


### PR DESCRIPTION
This PR includes examples of how a project can lint for callbacks. It also tweaks the readme to explain why arca needs to be loaded before the environment.

Proposal for #11
