### PR TITLE
Handle (non) backtick change in the callstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ have to update this test to make it pass.
 - [@jonmagic](https://github.com/jonmagic)
 - [@jch](https://github.com/jch)
 - [@bensheldon](https://github.com/bensheldon)
+- [@jasonkim](https://github.com/jasonkim)
 
 ## License
 

--- a/arca.gemspec
+++ b/arca.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "arca"
-  spec.version       = "2.3.0"
+  spec.version       = "2.3.1"
   spec.date          = "2015-08-07"
   spec.summary       = "ActiveRecord callback analyzer"
   spec.description   = "Arca is a callback analyzer for ActiveRecord ideally suited for digging yourself out of callback hell"

--- a/lib/arca/collector.rb
+++ b/lib/arca/collector.rb
@@ -6,7 +6,7 @@ module Arca
 
     # Internal: Regular expression used for extracting the file path and line
     # number from a caller line.
-    ARCA_CALLBACK_FINDER_REGEXP = /\A(.+)\:(\d+)\:in\s`.+'\z/
+    ARCA_CALLBACK_FINDER_REGEXP = /\A(.+)\:(\d+)\:in\s[`'].+'\z/
     private_constant :ARCA_CALLBACK_FINDER_REGEXP
 
     # Internal: Array of conditional symbols.
@@ -58,7 +58,7 @@ module Arca
 
             # Extract the model file path from the caller stack.
             caller.each do |line|
-              if match = /\A(.+):\d+:in\s`<class:#{name.split("::").last}>'/.match(line)
+              if match = /\A(.+):\d+:in\s[`']<class:#{name.split("::").last}>'/.match(line)
                 self.arca_callback_data[:model_file_path] = match[1]
                 break
               end


### PR DESCRIPTION
In Ruby 3.4, backtraces are now using a standard quote rather than backtick - https://github.com/ruby/ruby/pull/9608

There are two instances, which is substituted with
```
[`']
```
This should allow it to match either one.